### PR TITLE
'Crime Lord' need text fix

### DIFF
--- a/set/AW.json
+++ b/set/AW.json
@@ -605,7 +605,7 @@
             "Sp"
         ],
         "subtype_code": "ability",
-        "text": "[special] - Spend 5 resources to choose a character. That character is defeated after this round ends.",
+        "text": "Yellow Character only. [special] - Spend 5 resources to choose a character. That character is defeated after this round ends.",
         "ttscardid": "1322",
         "type_code": "upgrade"
     },


### PR DESCRIPTION
Card #23 'Crime Lord' in AW set.
"Yellow Character only." limitation is missing on card text.