### PR TITLE
fixed typo in card text.

### DIFF
--- a/set/EaW.json
+++ b/set/EaW.json
@@ -277,7 +277,7 @@
             "-"
         ],
         "subtitle": "Agile Inquisitor",
-        "text": "After you activate this character, you may roll and ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed.",
+        "text": "After you activate this character, you may roll an ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed.",
         "ttscardid": "3109",
         "type_code": "character"
     },

--- a/translations/es/set/EaW.json
+++ b/translations/es/set/EaW.json
@@ -59,7 +59,7 @@
         "code": "03010",
         "name": "Seventh Sister",
         "subtitle": "Agile Inquisitor",
-        "text": "After you activate this character, you may roll and ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed."
+        "text": "After you activate this character, you may roll an ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed."
     },
     {
         "code": "03011",

--- a/translations/zh/set/EaW.json
+++ b/translations/zh/set/EaW.json
@@ -30,7 +30,7 @@
         "code": "03010",
         "name": "Seventh Sister",
         "subtitle": "Agile Inquisitor",
-        "text": "After you activate this character, you may roll and ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed."
+        "text": "After you activate this character, you may roll an ID9 Seeker Droid ([EaW]13) die into your pool <em>(its X value is equal to the number of ID9 Seeker Droid dice in your pool)</em>. Set aside that die after it is resolved or removed."
     },
     {
         "code": "03012",


### PR DESCRIPTION
Seventh Sister has a typo in the card's description. This PR fixes it.