### PR TITLE
Fix Cost of Battle of Wills

### DIFF
--- a/set/EaW.json
+++ b/set/EaW.json
@@ -2873,7 +2873,7 @@
     {
         "affiliation_code": "neutral",
         "code": "03128",
-        "cost": 2,
+        "cost": 1,
         "deck_limit": 2,
         "faction_code": "blue",
         "has_die": false,


### PR DESCRIPTION
This fixes the cost of `Battle of Wills` from two to one.

![](http://swdestinydb.com/bundles/cards/en/03/03128.jpg)
