### PR TITLE
Updates for version 1.5 rules reference

### DIFF
--- a/set/AW.json
+++ b/set/AW.json
@@ -781,7 +781,7 @@
         "illustrator": "Tony Foti",
         "is_unique": true,
         "name": "Poe Dameron",
-        "points": "14/18",
+        "points": "16/20",
         "position": 29,
         "rarity_code": "L",
         "set_code": "AW",
@@ -2543,7 +2543,7 @@
         "position": 107,
         "rarity_code": "U",
         "set_code": "AW",
-        "text": "Ambush.\nChoose a symbol showing on an opponent's die. Then turn any number of your Red dice to sides showing that symbol.",
+        "text": "Choose a symbol showing on an opponent's die. Then turn up to 2 of your Red dice to sides showing that symbol.",
         "ttscardid": "1436",
         "type_code": "event"
     },

--- a/set/EaW.json
+++ b/set/EaW.json
@@ -2796,7 +2796,7 @@
         "position": 123,
         "rarity_code": "C",
         "set_code": "EaW",
-        "text": "Choose an opponent. That opponent turns any number of their dice to sides showing damage ([ranged] or [melee]). Turn any number of your dice to sides showing damage ([ranged] or [melee]).",
+        "text": "Choose an opponent. That opponent turns up to 2 of their dice to sides showing damage ([ranged] or [melee]). Turn up to 2 of your dice to sides showing damage ([ranged] or [melee]).",
         "ttscardid": "2652",
         "type_code": "event"
     },

--- a/set/SoR.json
+++ b/set/SoR.json
@@ -38,7 +38,7 @@
         "illustrator": "Audrey Hotte",
         "is_unique": true,
         "name": "FN-2199",
-        "points": "10/13",
+        "points": "12/15",
         "position": 2,
         "rarity_code": "R",
         "set_code": "SoR",
@@ -561,7 +561,7 @@
         "illustrator": "Sam Lamont",
         "is_unique": true,
         "name": "Unkar Plutt",
-        "points": "10/13",
+        "points": "12/15",
         "position": 21,
         "rarity_code": "R",
         "set_code": "SoR",
@@ -1556,7 +1556,7 @@
             "-"
         ],
         "subtype_code": "weapon",
-        "text": "Ambush.\nWhile this die is in your pool, melee damage ([melee]) dealt by your dice (<em>including this die</em>) is unblockable.",
+        "text": "Ambush.\nDamage dealt by this die or by dice it modifies is unblockable.",
         "ttscardid": "2256",
         "type_code": "upgrade"
     },
@@ -1816,7 +1816,7 @@
         "position": 70,
         "rarity_code": "U",
         "set_code": "SoR",
-        "text": "After one of your dice rolls a disrupt ([disrupt]), you may exhaust this support to return an upgrade in play that costs 2 or less to its owner's hand.",
+        "text": "After one of your dice rolls a disrupt ([disrupt]), you may set this support aside to return an upgrade in play that costs 2 or less to its owner's hand.",
         "ttscardid": "2269",
         "type_code": "support"
     },

--- a/set/TPG.json
+++ b/set/TPG.json
@@ -39,7 +39,7 @@
         "illustrator": "Leonid Kozienko",
         "is_unique": true,
         "name": "Captain Phasma",
-        "points": "9/13",
+        "points": "10/14",
         "position": 2,
         "rarity_code": "S",
         "set_code": "TPG",


### PR DESCRIPTION
Updated characters:
- Captain Phasma (2PCG)
- Unkar Plutt
- Poe Dameron
- FN-2199

Updated cards:
- It's a Trap
- Imperial Inspection
- Vibroknife
- Heat of Battle

https://images-cdn.fantasyflightgames.com/filer_public/38/a7/38a7c28b-8a85-4426-9fc2-d8fac35eb8bb/swd_rules_reference_15.pdf

![pasted_image_at_2017_10_24_04_32_pm_720](https://user-images.githubusercontent.com/563418/31970796-52dd7c1a-b8e7-11e7-8225-8d86aeb790c1.png)
![pasted_image_at_2017_10_24_04_32_pm_720-1](https://user-images.githubusercontent.com/563418/31970797-52e889c0-b8e7-11e7-999a-386bffa8ddf2.png)
