### PR TITLE
Changed card 05101 Ataru Strike position from 10 to 101.

### DIFF
--- a/set/LEG.json
+++ b/set/LEG.json
@@ -780,7 +780,7 @@
         "illustrator": "Audrey Hotte",
         "is_unique": false,
         "name": "Ataru Strike",
-        "position": 10,
+        "position": 101,
         "rarity_code": "R",
         "set_code": "LEG",
         "text": "Resolve one of your Blue character dice showing melee damage ([melee]), increaing its value by the number of shields on that character.",


### PR DESCRIPTION
Fix for issue [#74](https://github.com/fafranco82/swdestinydb-json-data/issues/74). Update set number for the card [(05101) Ataru Strike](https://swdestinydb.com/card/05101) from the Legacies set from 10 to 101.