### PR TITLE
Update pattern matches for dice sides. This should prevent bad sides like 1Sp.

### DIFF
--- a/schema/card_schema.json
+++ b/schema/card_schema.json
@@ -88,7 +88,7 @@
         },
         "sides": {
             "items": {
-                "pattern": "^[+]?(\\d+)?(MD|RD|ID|F|Dr|Dc|Sh|R|Sp|-|X)(\\d+)?$",
+                "pattern": "^((([+]?(\\d+)(MD|RD|ID|F|Dr|Dc|Sh|R|X)|Sp)(\\d+)?)|-)$",
                 "type": "string"
             },
             "maxItems": 6,


### PR DESCRIPTION

This new pattern breaks the side types into two groups.
1) Sides that can have a leading '+' and/or a leading digit (3RD, +3ID)
2) Sides don't have any leading or trailing digits (-)

It further breaks group 1 into two groups
1a) Sides that can have leading and trailing characters (MD,RD, etc.)
1b) Sides that can only have trailing characters (Sp1)

^((    ([+]?(\\d+)(MD|RD|ID|F|Dr|Dc|Sh|R|X)|Sp)(\\d+)?)    |     -      )$
                                         ^^^^^^^                                                ^^^^
                                         Group 1                                            Group 2

([+]?(\\d+)(MD|RD|ID|F|Dr|Dc|Sh|R|X)   |       Sp      )         (\\d+)?) 
                    ^^^^^^^^                                    ^^^^^^^^^            ^^^^^^^
                    Group 1a                                  Group 1b            1a&1b can have a trailing digit.

*rough ASCII explanation of regex. 😃 