### PR TITLE
Add set names in portuguese

### DIFF
--- a/translations/pt/sets.json
+++ b/translations/pt/sets.json
@@ -1,6 +1,30 @@
 [
     {
         "code": "AW",
-        "name": "Despertares"
+        "name": "Despertar"
+    },
+	{
+        "code": "SoR",
+        "name": "Espírito da Rebelião"
+    },
+	{
+        "code": "EaW",
+        "name": "Império em Guerra"
+    },
+	{
+        "code": "TPG",
+        "name": "Jogo para 2 Jogadores"
+    },
+	{
+        "code": "LEG",
+        "name": "Legados"
+    },
+	{
+        "code": "RIV",
+        "name": "Rivais"
+    },
+	{
+        "code": "WotF",
+        "name": "Caminho da Força"
     }
 ]


### PR DESCRIPTION
Forgot to add set names in portuguese as well... just a small note, those are Portuguese from Brazil and not Portugal!
Maybe you can change the flag at the website (and add 2 folders as `ptBr` and `ptPt`)