### PR TITLE
Updated misspelling of Perseverance card

### DIFF
--- a/set/LEG.json
+++ b/set/LEG.json
@@ -3277,7 +3277,7 @@
         "has_errata": false,
         "illustrator": "Cristi Balanescu",
         "is_unique": false,
-        "name": "Perserverance",
+        "name": "Perseverance",
         "position": 134,
         "rarity_code": "C",
         "set_code": "LEG",


### PR DESCRIPTION
The image is also incorrect (must have been a spoiled card that was corrected before printing).  I have verified the card with the card from my collection.