### PR TITLE
Fixed [indirect] error on Imperialis in text section.

### DIFF
--- a/set/CONV.json
+++ b/set/CONV.json
@@ -288,7 +288,7 @@
         "subtypes": [
             "vehicle"
         ],
-        "text": "After you activate Palpatine, you may activate this support.\n[special] - Discard this support from play to deal 4 indirect damage ([Indirect]) to an opponent.",
+        "text": "After you activate Palpatine, you may activate this support.\n[special] - Discard this support from play to deal 4 indirect damage ([indirect]) to an opponent.",
         "type_code": "support"
     },
     {


### PR DESCRIPTION
Capitalization leads to the front-end being unable to recognize the use of the indirect icon.