### PR TITLE
Fix : Deck limit wrong for one card + some french typos

### DIFF
--- a/set/CONV.json
+++ b/set/CONV.json
@@ -2816,7 +2816,7 @@
         "affiliation_code": "neutral",
         "code": "09116",
         "cost": 1,
-        "deck_limit": 1,
+        "deck_limit": 2,
         "faction_code": "blue",
         "flavor": "\"It's not just about lifting rocks. The Force binds everything together\" <cite>Luke Skywalker</cite>",
         "has_die": false,

--- a/translations/fr/set/LEG.json
+++ b/translations/fr/set/LEG.json
@@ -180,7 +180,7 @@
     {
         "code": "05034",
         "name": "ETA-2 Interceptor",
-        "text": "<b>Action</b> - Retirez ce dé ou un de vos dés montrant un bouclier ([shield]) pour incliner un soutien.."
+        "text": "<b>Action</b> - Retirez ce dé ou un de vos dés montrant un bouclier ([shield]) pour incliner un soutien."
     },
     {
         "code": "05035",
@@ -871,7 +871,7 @@
     },
     {
         "code": "05171",
-        "name": "Contact frucuteux",
+        "name": "Contact fructueux",
         "text": "Vous commencez la partie avec 1 ressource supplémentaire."
     },
     {
@@ -888,13 +888,13 @@
         "code": "05174",
         "name": "Désolation aride",
         "subtitle": "Geonosis",
-        "text": "<b>Capture</b> - Forcez un adversaire à perdre 1 ressource.."
+        "text": "<b>Capture</b> - Forcez un adversaire à perdre 1 ressource."
     },
     {
         "code": "05175",
         "name": "Zone d'atterrissage de la citadelle",
         "subtitle": "Scarif",
-        "text": "<b>Capture</b> - Relancez n'importe quel nombre de vos dés. Puis vous pouvez résoudre un de vos dés.."
+        "text": "<b>Capture</b> - Relancez n'importe quel nombre de vos dés. Puis vous pouvez résoudre un de vos dés."
     },
     {
         "code": "05176",

--- a/translations/fr/set/RIV.json
+++ b/translations/fr/set/RIV.json
@@ -55,7 +55,7 @@
     {
         "code": "06011",
         "name": "Ressembler",
-        "text": "Tournez un dé de personnage sur n'importe quelle face, s'il y a au moins 2 exemplaires de ce personnage en jeu.."
+        "text": "Tournez un dé de personnage sur n'importe quelle face, s'il y a au moins 2 exemplaires de ce personnage en jeu."
     },
     {
         "code": "06012",


### PR DESCRIPTION
The deck limit of It Binds All Things should be 2 and not 1.
+ Some french typos (avoiding a branch for those little typos)